### PR TITLE
Add support for Kraken 2 paired end reads

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -89,7 +89,6 @@ kraken2 <- function(tool_args = "", read_one = NULL, read_two = NULL, output_pat
   } else {
     read_one <- .validate.inpath(read_one)
   }
-  cat(sprintf("Read one: %s.\n", read_one))
   output_path <- .validate.outpath(output_path)
   toolchest_args <- list(
     tool_args = tool_args,


### PR DESCRIPTION
Adds:
- Support for Kraken 2 paired-end reads

Removes:
- `inputs` argument for Kraken 2 (replaced by `read_one` and `read_two`)

Example usage:
```
toolchest::kraken2(
    read_one="./sample_r1.fastq.gz", 
    read_two="./sample_r2.fastq.gz",
    output_path="./paired_output.txt"
)
```

Corresponds to support added in https://github.com/trytoolchest/toolchest-client-python/pull/39 and https://github.com/trytoolchest/toolchest-client-python/pull/42